### PR TITLE
Updated workflow to autogenerate an empty Development.xcconfig in iOS…

### DIFF
--- a/.github/workflows/ios_and_watch.yml
+++ b/.github/workflows/ios_and_watch.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Create Development.xcconfig
+        run: |
+          cat > Development.xcconfig << 'EOF'
+          EOF
+
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
@@ -52,6 +57,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Create Development.xcconfig
+        run: |
+          cat > Development.xcconfig << 'EOF'
+          EOF
+
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
@@ -64,7 +74,8 @@ jobs:
           scheme: ${{ 'default' }}
           platform: ${{ 'watchOS Simulator' }}
         run: |
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'Apple Watch.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
+          device=`xcrun xctrace list devices 2>&1 | grep -oE 'Apple Watch Series [0-9]+[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
+          if [ -z "$device" ]; then device=`xcrun xctrace list devices 2>&1 | grep -oE 'Apple Watch[^(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`; fi
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
@@ -75,7 +86,8 @@ jobs:
           scheme: ${{ 'default' }}
           platform: ${{ 'watchOS Simulator' }}
         run: |
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'Apple Watch.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
+          device=`xcrun xctrace list devices 2>&1 | grep -oE 'Apple Watch Series [0-9]+[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
+          if [ -z "$device" ]; then device=`xcrun xctrace list devices 2>&1 | grep -oE 'Apple Watch[^(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`; fi
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`


### PR DESCRIPTION
… and watchOS workflows and use a different simulator for apple watch

Add step to create Development.xcconfig in workflows