### PR TITLE
Pomodoro Timer Drifting

### DIFF
--- a/FocusWatch App.xcodeproj/project.pbxproj
+++ b/FocusWatch App.xcodeproj/project.pbxproj
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "watch-notification/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = FocusWatch;
@@ -748,7 +748,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.9;
+				MARKETING_VERSION = 1.2.10;
 				PRODUCT_BUNDLE_IDENTIFIER = net.com.fokusuhr.FokusUhr.watchkitapp.notification;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -765,7 +765,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "watch-notification/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = FocusWatch;
@@ -777,7 +777,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.9;
+				MARKETING_VERSION = 1.2.10;
 				PRODUCT_BUNDLE_IDENTIFIER = net.com.fokusuhr.FokusUhr.watchkitapp.notification;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -798,7 +798,7 @@
 				CODE_SIGN_ENTITLEMENTS = "watch-version-complication/widgetExtension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "watch-version-complication/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = FocusWatch;
@@ -810,7 +810,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.9;
+				MARKETING_VERSION = 1.2.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "net.com.fokusuhr.FokusUhr.watchkitapp.version-complication";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -830,7 +830,7 @@
 				CODE_SIGN_ENTITLEMENTS = "watch-version-complication/widgetExtension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "watch-version-complication/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = FocusWatch;
@@ -842,7 +842,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.9;
+				MARKETING_VERSION = 1.2.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "net.com.fokusuhr.FokusUhr.watchkitapp.version-complication";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -990,7 +990,7 @@
 				CODE_SIGN_ENTITLEMENTS = watch/watch.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"watch/Preview Content\"";
 				DEVELOPMENT_TEAM = 9LKY7MBW4C;
 				ENABLE_PREVIEWS = YES;
@@ -1010,7 +1010,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.9;
+				MARKETING_VERSION = 1.2.10;
 				PRODUCT_BUNDLE_IDENTIFIER = net.com.fokusuhr.FokusUhr.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1032,7 +1032,7 @@
 				CODE_SIGN_ENTITLEMENTS = watch/watch.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"watch/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1051,7 +1051,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.9;
+				MARKETING_VERSION = 1.2.10;
 				PRODUCT_BUNDLE_IDENTIFIER = net.com.fokusuhr.FokusUhr.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1074,7 +1074,7 @@
 				CODE_SIGN_ENTITLEMENTS = companion/companion.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"companion/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1094,7 +1094,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.9;
+				MARKETING_VERSION = 1.2.10;
 				PRODUCT_BUNDLE_IDENTIFIER = net.com.fokusuhr.FokusUhr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1118,7 +1118,7 @@
 				CODE_SIGN_ENTITLEMENTS = companion/companion.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"companion/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1138,7 +1138,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.9;
+				MARKETING_VERSION = 1.2.10;
 				PRODUCT_BUNDLE_IDENTIFIER = net.com.fokusuhr.FokusUhr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/watch/Views/Pomodoro/PomodoroViewModel.swift
+++ b/watch/Views/Pomodoro/PomodoroViewModel.swift
@@ -23,7 +23,6 @@ class PomodoroViewModel: NSObject, ObservableObject, WKExtendedRuntimeSessionDel
   private var extendedRuntimeSession: WKExtendedRuntimeSession?
   private var totalTime: Int = 1500
   private var endDate: Date?
-  private var lastTickDate: Date?
 
   private var isLoadingSettings = false
 
@@ -253,7 +252,6 @@ class PomodoroViewModel: NSObject, ObservableObject, WKExtendedRuntimeSessionDel
 
   private func startTimer() {
     endDate = Date().addingTimeInterval(TimeInterval(timeRemaining))
-    lastTickDate = Date()
 
     scheduleTimerNotification()
 
@@ -283,14 +281,19 @@ class PomodoroViewModel: NSObject, ObservableObject, WKExtendedRuntimeSessionDel
     #endif
 
     timerTask = Task {
+      guard let deadline = endDate else { return }
       while !Task.isCancelled {
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        let now = Date()
+        let remaining = deadline.timeIntervalSince(now)
+        if remaining <= 0 {
+          timeRemaining = 0
+          break
+        }
+        let nextTick = remaining.truncatingRemainder(dividingBy: 1.0)
+        let sleepDuration = nextTick < 0.05 ? 1.0 : nextTick
+        try? await Task.sleep(nanoseconds: UInt64(sleepDuration * 1_000_000_000))
         if !Task.isCancelled {
           await tick()
-        }
-
-        if timeRemaining <= 0 {
-          break
         }
       }
       if !Task.isCancelled && timeRemaining <= 0 {
@@ -303,7 +306,6 @@ class PomodoroViewModel: NSObject, ObservableObject, WKExtendedRuntimeSessionDel
     timerTask?.cancel()
     timerTask = nil
     endDate = nil
-    lastTickDate = nil
 
     // Always stop vibrations when timer stops
     VibrationManager.shared.stopPomodoroRandomVibrations()
@@ -324,23 +326,9 @@ class PomodoroViewModel: NSObject, ObservableObject, WKExtendedRuntimeSessionDel
   }
 
   private func tick() async {
-    let now = Date()
-
-    if let lastTick = lastTickDate {
-      let timeSinceLastTick = now.timeIntervalSince(lastTick)
-      if timeSinceLastTick < 0.9 {
-        return
-      }
-    }
-
-    lastTickDate = now
-
-    if let endDate = endDate {
-      let remaining = Int(ceil(endDate.timeIntervalSince(now)))
-      timeRemaining = max(0, remaining)
-    } else {
-      timeRemaining = max(0, timeRemaining - 1)
-    }
+    guard let endDate = endDate else { return }
+    let remaining = Int(ceil(endDate.timeIntervalSince(Date())))
+    timeRemaining = max(0, remaining)
 
     if timeRemaining % 10 == 0 {
       saveState()


### PR DESCRIPTION
Timer loop (startTimer) -> Instead of a fixed Task​.sleep(1 second) that drifts, the loop now:

1. Captures the end​Date deadline once
2. Computes how long until the next whole-second boundary of the countdown (remaining % 1​.0)
3. Sleeps exactly that duration, so each tick aligns with the wall clock

tick(), simplified to just recompute time​Remaining from end​Date. Removed the last​Tick​Date debounce guard and the fallback decrement-by-one path, both of which are now unnecessary.

Removed lastTickDate, The property and all its assignments were deleted since the drift-free sleep scheduling makes it redundant