### PR TITLE
Initial test suite

### DIFF
--- a/.github/workflows/ios_and_watch.yml
+++ b/.github/workflows/ios_and_watch.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build & Test (iOS)
         run: |
-            device=$(xcrun simctl list devices available | grep "iPhone 16" | grep -v "Plus\|Pro\|Max" | head -1 | sed 's/.*(\([A-F0-9-]*\)).*/\1/')
+            device=$(xcrun simctl list devices available | grep "iPhone 17 Pro" | grep -v "Max" | head -1 | sed 's/.*(\([A-F0-9-]*\)).*/\1/')
             xcodebuild test \
             -scheme "companion" \
             -project "FocusWatch App.xcodeproj" \
@@ -34,7 +34,7 @@ jobs:
 
   build-and-test-watchos:
     name: Build & Test watchOS
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build & Test (watchOS)
         run: |
-            device=$(xcrun simctl list devices available | grep "Apple Watch Series 11 (46mm)" | head -1 | sed 's/.*(\([A-F0-9-]*\)).*/\1/')
+            device=$(xcrun simctl list devices available | grep "Apple Watch Series 11 (42mm)" | head -1 | sed 's/.*(\([A-F0-9-]*\)).*/\1/')
             xcodebuild test \
             -scheme "watch" \
             -project "FocusWatch App.xcodeproj" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,26 @@ FocusWatch is a watchOS + iOS Swift app for users with focus difficulties. It ha
 - **`shared`** — Swift framework shared between both apps (data models, WatchConnectivity sync, Supabase)
 - **`watch-notification`** / **`watch-version-complication`** — watchOS extensions
 
+## Setup
+
+1. `supabase start` in project root (requires Docker Desktop + Supabase CLI)
+2. Copy `Example.xcconfig` to `Development.xcconfig`, populate `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `GOOGLE_DRIVE_USERNAME`, `GOOGLE_DRIVE_PASSWORD`
+3. Configure valid Developer Team in Xcode Signing & Capabilities for all targets
+
 ## Build & Run Commands
 
-Don't trigger builds yourself.
+Don't trigger builds yourself. Makefile targets for reference:
+
+```
+make ios-build        # Build iOS scheme for simulator
+make ios-test         # Run iOS tests (iPhone 17 sim)
+make watch-build      # Build watchOS scheme for simulator
+make watch-test       # Run watchOS tests (Apple Watch Series 11 46mm sim)
+make dev              # Launch iOS + watch apps concurrently
+make all-test         # Run both test suites
+```
+
+Simulator name overrides: `IOS_SIM_NAME`, `WATCH_SIM_NAME`, `IOS_TEST_SIM_NAME`, `WATCH_TEST_SIM_NAME`.
 
 ## Architecture
 
@@ -41,6 +58,16 @@ Watch App  ──WatchConnectivity──  Companion App
 - `companion/Services/GalleryStorage.swift` — Image resizing, compression, debounced persistence
 - `watch/Services/GalleryManager.swift` — Receives transferred files from iOS
 
+### Sync Architecture
+
+`SyncCoordinator` (companion) owns a `SyncCommandRouter` and all per-domain sync services (`CalendarSyncService`, `ChecklistSyncService`, `LevelSyncService`, `ConfigSyncService`, `AuthSyncService`, `TelemetrySyncService`, `CommandSyncService`, `ImageSyncService`). Each service registers its action handlers on the router. Messages cross the WatchConnectivity boundary as `SyncPacket` (typed, JSON-encoded) using `SyncTransportProtocol` — the production impl is `ConnectivityTransportAdapter`.
+
+Watch-side receives via `shared/Connectivity/` and routes through the same router pattern. New sync domains must: add a key to `SyncConstants.Keys`, an action to `SyncConstants.Actions`, register a handler on `SyncCommandRouter`, and handle both send and receive sides.
+
+### Watch Feature Views
+
+`watch/Views/` contains standalone focus tools: `Writing/` (EMA writing detection), `Pomodoro/`, `ColorBreathing/`, `FidgetToy/`, `Speedometer/`, `Level/`, `Checklist/`, `Calendar/`, `Progress/`, `Settings/`, `Dashboard/`.
+
 ### Writing Detection (Watch)
 
 EMA-based accelerometer model in `watch/Views/Writing/`. `EmaModel` processes motion samples; `WritingMotionManager`, `WritingTimeManager`, and `WritingHapticFeedbackManager` handle the subsystems.
@@ -51,6 +78,7 @@ EMA-based accelerometer model in `watch/Views/Writing/`. `EmaModel` processes mo
 - **async/await over GCD** — use Swift Structured Concurrency; avoid `DispatchQueue` for new code.
 - **No magic strings** — all storage keys and hardcoded values belong in `AppConstants` or `SyncConstants`.
 - **Logging** — use `AppLogger` for telemetry events, `ErrorLogger` for debug/error logging.
+- **Tests** — use Swift Testing (`@Suite`, `@Test`, `#expect`), not XCTest. Test targets: `watch-testing`, `companion-testing`.
 - **Branching** — `feature/issue-number-description` or `fix/issue-number-description`; no direct commits to `main`; PRs must reference an open issue.
 - All tests must pass before merging.
 - Make sure new features or adjustments dont break backwards compatibility

--- a/FocusWatch App.xcodeproj/xcuserdata/eliasalerno.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/FocusWatch App.xcodeproj/xcuserdata/eliasalerno.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,12 +12,12 @@
 		<key>focuswatch-watch-notification.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>2</integer>
 		</dict>
 		<key>focuswatch-watch-version-complication.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>3</integer>
 		</dict>
 		<key>notification.xcscheme_^#shared#^_</key>
 		<dict>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT := focuswatch.xcodeproj
+PROJECT := FocusWatch App.xcodeproj
 IOS_SCHEME := companion
 WATCH_SCHEME := watch
 

--- a/companion-testing/AppConfigurationsTests.swift
+++ b/companion-testing/AppConfigurationsTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import focuswatch_companion
+
+@Suite("AppConfigurations Codable")
+struct AppConfigurationsTests {
+        @Test("Default AppConfigurations round-trips")
+        func defaultAppConfigurationsRoundTrips() throws {
+            let config = AppConfigurations.default
+            let data = try JSONEncoder().encode(config)
+            let decoded = try JSONDecoder().decode(AppConfigurations.self, from: data)
+            #expect(decoded == config)
+        }
+
+        @Test("PomodoroConfiguration round-trips with non-default values")
+        func pomodoroConfigurationRoundTrips() throws {
+            var config = PomodoroConfiguration()
+            config.workMinutes = 45
+            config.shortBreakMinutes = 10
+            config.roundsUntilLongBreak = 6
+            let data = try JSONEncoder().encode(config)
+            let decoded = try JSONDecoder().decode(PomodoroConfiguration.self, from: data)
+            #expect(decoded == config)
+        }
+
+        @Test("ColorBreathingConfiguration round-trips with non-default values")
+        func colorBreathingConfigurationRoundTrips() throws {
+            var config = ColorBreathingConfiguration()
+            config.inhaleSeconds = 6
+            config.exhaleSeconds = 8
+            config.cycleCount = 10
+            let data = try JSONEncoder().encode(config)
+            let decoded = try JSONDecoder().decode(ColorBreathingConfiguration.self, from: data)
+            #expect(decoded == config)
+        }
+
+        @Test("FokusMeterConfiguration round-trips")
+        func fokusMeterConfigurationRoundTrips() throws {
+            let config = FokusMeterConfiguration()
+            let data = try JSONEncoder().encode(config)
+            let decoded = try JSONDecoder().decode(FokusMeterConfiguration.self, from: data)
+            #expect(decoded == config)
+        }
+
+        @Test("Partial JSON decodes with defaults for missing keys")
+        func partialJSONDecodesWithDefaults() throws {
+            let json = Data("{}".utf8)
+            let decoded = try JSONDecoder().decode(AppConfigurations.self, from: json)
+            let def = AppConfigurations.default
+            #expect(decoded == def)
+        }
+
+        @Test("ColorBreathing partial JSON uses defaults for missing keys")
+        func colorBreathingPartialJSONUsesDefaults() throws {
+            let json = Data("{\"inhaleSeconds\": 8}".utf8)
+            let decoded = try JSONDecoder().decode(ColorBreathingConfiguration.self, from: json)
+            #expect(decoded.inhaleSeconds == 8)
+            #expect(decoded.exhaleSeconds == 4)
+            #expect(decoded.cycleCount == 5)
+        }
+
+        @Test("ChecklistSwipeDirectionMapping collect and delay directions are inverse")
+        func checklistSwipeMappingCollectAndDelayAreInverse() {
+            for mapping in ChecklistSwipeDirectionMapping.allCases {
+                #expect(mapping.collectDirection != mapping.delayDirection)
+            }
+        }
+
+        @Test("ChecklistSwipeDirectionMapping round-trips")
+        func checklistSwipeMappingRoundTrips() throws {
+            for mapping in ChecklistSwipeDirectionMapping.allCases {
+                let data = try JSONEncoder().encode(mapping)
+                let decoded = try JSONDecoder().decode(ChecklistSwipeDirectionMapping.self, from: data)
+                #expect(decoded == mapping)
+            }
+        }
+}

--- a/companion-testing/ChecklistDataStoreTests.swift
+++ b/companion-testing/ChecklistDataStoreTests.swift
@@ -1,0 +1,48 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import focuswatch_companion
+
+@Suite("ChecklistDataStore")
+struct ChecklistDataStoreTests {
+        private func makeDefaults() -> UserDefaults {
+            UserDefaults(suiteName: UUID().uuidString)!
+        }
+
+        @Test("Init with empty defaults loads default ChecklistData")
+        func initWithEmptyDefaultsLoadsDefaultChecklistData() {
+            let store = ChecklistDataStore(userDefaults: makeDefaults(), debounceInterval: 0.0)
+            #expect(store.checklistData.checklists.count == ChecklistData.default.checklists.count)
+        }
+
+        @Test("updateChecklistData publishes new value")
+        func updateChecklistDataPublishesNewValue() {
+            let store = ChecklistDataStore(userDefaults: makeDefaults(), debounceInterval: 0.0)
+            let newData = ChecklistData(checklists: [Checklist(name: "Updated")])
+            store.updateChecklistData(newData)
+            #expect(store.checklistData.checklists.first?.name == "Updated")
+        }
+
+        @Test("Corrupted defaults loads default")
+        func corruptedDefaultsLoadsDefault() {
+            let defaults = makeDefaults()
+            defaults.set(Data([0xFF, 0xFE, 0x00]), forKey: AppConstants.StorageKeys.checklistData)
+            let store = ChecklistDataStore(userDefaults: defaults, debounceInterval: 0.0)
+            #expect(store.checklistData.checklists.count == ChecklistData.default.checklists.count)
+        }
+
+        @Test("updateChecklistData persists after reinit")
+        @MainActor
+        func updateChecklistDataPersistsAfterReinit() async throws {
+            let defaults = makeDefaults()
+            let store = ChecklistDataStore(userDefaults: defaults, debounceInterval: 0.0)
+            let newData = ChecklistData(checklists: [Checklist(name: "Persisted")])
+            store.updateChecklistData(newData)
+
+            try await Task.sleep(nanoseconds: 50_000_000)
+
+            let store2 = ChecklistDataStore(userDefaults: defaults, debounceInterval: 0.0)
+            #expect(store2.checklistData.checklists.first?.name == "Persisted")
+        }
+}

--- a/companion-testing/ChecklistModelsTests.swift
+++ b/companion-testing/ChecklistModelsTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import focuswatch_companion
+
+@Suite("Checklist Models")
+struct ChecklistModelsTests {
+        @Test("ChecklistItem round-trips")
+        func checklistItemRoundTrips() throws {
+            let item = ChecklistItem(title: "Test Item", imageName: "img")
+            let data = try JSONEncoder().encode(item)
+            let decoded = try JSONDecoder().decode(ChecklistItem.self, from: data)
+            #expect(decoded.title == item.title)
+            #expect(decoded.imageName == item.imageName)
+        }
+
+        @Test("Checklist with all fields round-trips")
+        func checklistWithAllFieldsRoundTrips() throws {
+            let checklist = Checklist(
+                name: "Test",
+                emoji: "T",
+                tag: "tag",
+                description: "desc",
+                items: [ChecklistItem(title: "A", imageName: "a")],
+                xpReward: 75,
+                resetConfiguration: ChecklistResetConfiguration(interval: .daily, hour: 8, minute: 30),
+                swipeMapping: .collectLeftDelayRight
+            )
+            let data = try JSONEncoder().encode(checklist)
+            let decoded = try JSONDecoder().decode(Checklist.self, from: data)
+            #expect(decoded.name == checklist.name)
+            #expect(decoded.emoji == checklist.emoji)
+            #expect(decoded.tag == checklist.tag)
+            #expect(decoded.xpReward == checklist.xpReward)
+            #expect(decoded.items.count == 1)
+            #expect(decoded.swipeMapping == checklist.swipeMapping)
+        }
+
+        @Test("Checklist decodes with missing optional fields using defaults")
+        func checklistDecodesWithMissingOptionalFields() throws {
+            let json = Data("{\"name\": \"Minimal\"}".utf8)
+            let decoded = try JSONDecoder().decode(Checklist.self, from: json)
+            #expect(decoded.name == "Minimal")
+            #expect(decoded.emoji == "")
+            #expect(decoded.tag == "")
+            #expect(decoded.items.isEmpty)
+            #expect(decoded.xpReward == 50)
+            #expect(decoded.swipeMapping == .collectRightDelayLeft)
+        }
+
+        @Test("ChecklistResetConfiguration clamps hour to 0-23")
+        func checklistResetConfigurationClampsHour() {
+            let low = ChecklistResetConfiguration(hour: -1)
+            #expect(low.hour == 0)
+            let high = ChecklistResetConfiguration(hour: 25)
+            #expect(high.hour == 23)
+            let valid = ChecklistResetConfiguration(hour: 12)
+            #expect(valid.hour == 12)
+        }
+
+        @Test("ChecklistResetConfiguration clamps minute to 0-59")
+        func checklistResetConfigurationClampsMinute() {
+            let low = ChecklistResetConfiguration(minute: -5)
+            #expect(low.minute == 0)
+            let high = ChecklistResetConfiguration(minute: 60)
+            #expect(high.minute == 59)
+        }
+
+        @Test("ChecklistResetConfiguration clamps weekday to 1-7")
+        func checklistResetConfigurationClampsWeekday() {
+            let low = ChecklistResetConfiguration(weekday: 0)
+            #expect(low.weekday == 1)
+            let high = ChecklistResetConfiguration(weekday: 8)
+            #expect(high.weekday == 7)
+        }
+
+        @Test("ChecklistData default contains one checklist")
+        func checklistDataDefaultContainsOneChecklist() {
+            #expect(ChecklistData.default.checklists.count == 1)
+        }
+
+        @Test("ChecklistData round-trips")
+        func checklistDataRoundTrips() throws {
+            let original = ChecklistData.default
+            let data = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(ChecklistData.self, from: data)
+            #expect(decoded.checklists.count == original.checklists.count)
+            #expect(decoded.checklists.first?.name == original.checklists.first?.name)
+        }
+}

--- a/companion-testing/LevelProgressModelTests.swift
+++ b/companion-testing/LevelProgressModelTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+
+@testable import focuswatch_companion
+
+@Suite("LevelProgress Model")
+struct LevelProgressModelTests {
+        @Test("xpForLevel scales linearly by 100 per level")
+        func xpForLevelScalesLinearly() {
+            #expect(LevelProgress.xpForLevel(1) == 100)
+            #expect(LevelProgress.xpForLevel(5) == 500)
+            #expect(LevelProgress.xpForLevel(10) == 1000)
+        }
+
+        @Test("xpNeededForNextLevel is current level + 1 * 100")
+        func xpNeededForNextLevelIsCurrentLevelPlusOne() {
+            let progress = LevelProgress(currentLevel: 3, currentXP: 0)
+            #expect(progress.xpNeededForNextLevel == 400)
+        }
+
+        @Test("progressToNextLevel is zero at start")
+        func progressToNextLevelIsZeroAtStart() {
+            let progress = LevelProgress(currentLevel: 1, currentXP: 0)
+            #expect(progress.progressToNextLevel == 0.0)
+        }
+
+        @Test("progressToNextLevel is correct fraction")
+        func progressToNextLevelIsCorrectFraction() {
+            let progress = LevelProgress(currentLevel: 1, currentXP: 100)
+            #expect(abs(progress.progressToNextLevel - 0.5) < 0.0001)
+        }
+
+        @Test("progressToNextLevel caps at 1.0 when xp equals threshold")
+        func progressToNextLevelCapsAtOne() {
+            let progress = LevelProgress(currentLevel: 1, currentXP: 200)
+            #expect(progress.progressToNextLevel == 1.0)
+        }
+
+        @Test("progressToNextLevel guard against zero denominator")
+        func progressToNextLevelGuardsAgainstZeroDenominator() {
+            let progress = LevelProgress(currentLevel: 0, currentXP: 0)
+            #expect(progress.progressToNextLevel == 0.0)
+        }
+}

--- a/companion-testing/LevelServiceActivitiesTests.swift
+++ b/companion-testing/LevelServiceActivitiesTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+
+@testable import focuswatch_companion
+
+@Suite("LevelService ActivityType")
+struct LevelServiceActivitiesTests {
+        @Test("checklistCompleted xp reward is 50")
+        func checklistCompletedXPRewardIs50() {
+            #expect(LevelService.ActivityType.checklistCompleted.xpReward == 50)
+        }
+
+        @Test("pomodoroCompleted xp reward is 100")
+        func pomodoroCompletedXPRewardIs100() {
+            #expect(LevelService.ActivityType.pomodoroCompleted.xpReward == 100)
+        }
+
+        @Test("writingSession xp reward is 75")
+        func writingSessionXPRewardIs75() {
+            #expect(LevelService.ActivityType.writingSession.xpReward == 75)
+        }
+
+        @Test("breathingExercise xp reward is 30")
+        func breathingExerciseXPRewardIs30() {
+            #expect(LevelService.ActivityType.breathingExercise.xpReward == 30)
+        }
+
+        @Test("fidgetUsed xp reward is 10")
+        func fidgetUsedXPRewardIs10() {
+            #expect(LevelService.ActivityType.fidgetUsed.xpReward == 10)
+        }
+
+        @Test("calendarEventCreated xp reward is 25")
+        func calendarEventCreatedXPRewardIs25() {
+            #expect(LevelService.ActivityType.calendarEventCreated.xpReward == 25)
+        }
+
+        @Test("journalEntry xp reward is 40")
+        func journalEntryXPRewardIs40() {
+            #expect(LevelService.ActivityType.journalEntry.xpReward == 40)
+        }
+
+        @Test("custom xp reward is 0")
+        func customXPRewardIsZero() {
+            #expect(LevelService.ActivityType.custom.xpReward == 0)
+        }
+
+        @Test("appName is non-empty for all cases")
+        func appNameIsNonEmptyForAllCases() {
+            let cases: [LevelService.ActivityType] = [
+                .checklistCompleted, .pomodoroCompleted, .writingSession,
+                .breathingExercise, .fidgetUsed, .calendarEventCreated,
+                .journalEntry, .custom
+            ]
+            for activity in cases {
+                #expect(!activity.appName.isEmpty)
+            }
+        }
+}

--- a/companion-testing/MockSyncSessionStateStore.swift
+++ b/companion-testing/MockSyncSessionStateStore.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+@testable import focuswatch_companion
+
+final class MockSyncSessionStateStore: SyncSessionStateStore {
+    var storedState: SyncState?
+    var storedHistory: [SyncState] = []
+
+    func loadCurrentState() -> SyncState? {
+        storedState
+    }
+
+    func loadHistory() -> [SyncState] {
+        storedHistory
+    }
+
+    func saveCurrentState(_ state: SyncState?) {
+        storedState = state
+    }
+
+    func saveHistory(_ history: [SyncState]) {
+        storedHistory = history
+    }
+
+    func clear() {
+        storedState = nil
+        storedHistory = []
+    }
+}

--- a/companion-testing/SyncCommandRouterTests.swift
+++ b/companion-testing/SyncCommandRouterTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import focuswatch_companion
+
+@Suite("SyncCommandRouter")
+struct SyncCommandRouterTests {
+        @Test("Registered handler is invoked for matching action")
+        func registeredHandlerIsInvokedForMatchingAction() {
+            let router = SyncCommandRouter()
+            var called = false
+            router.register(action: "doThing") { _, _ in called = true }
+            router.route(message: [SyncConstants.Keys.action: "doThing"], replyHandler: nil)
+            #expect(called)
+        }
+
+        @Test("Route returns true for known action")
+        func routeReturnsTrueForKnownAction() {
+            let router = SyncCommandRouter()
+            router.register(action: "known") { _, _ in }
+            let result = router.route(message: [SyncConstants.Keys.action: "known"], replyHandler: nil)
+            #expect(result)
+        }
+
+        @Test("Route returns false for unknown action")
+        func routeReturnsFalseForUnknownAction() {
+            let router = SyncCommandRouter()
+            let result = router.route(message: [SyncConstants.Keys.action: "nope"], replyHandler: nil)
+            #expect(!result)
+        }
+
+        @Test("Route returns false when action key is missing")
+        func routeReturnsFalseWhenActionKeyMissing() {
+            let router = SyncCommandRouter()
+            router.register(action: "something") { _, _ in }
+            let result = router.route(message: ["other": "val"], replyHandler: nil)
+            #expect(!result)
+        }
+
+        @Test("Unregistered handler is not invoked")
+        func unregisteredHandlerIsNotInvoked() {
+            let router = SyncCommandRouter()
+            var called = false
+            router.register(action: "act") { _, _ in called = true }
+            router.unregister(action: "act")
+            router.route(message: [SyncConstants.Keys.action: "act"], replyHandler: nil)
+            #expect(!called)
+        }
+
+        @Test("Reply handler is forwarded to registered handler")
+        func replyHandlerIsForwardedToRegisteredHandler() {
+            let router = SyncCommandRouter()
+            var receivedReply: (([String: Any]) -> Void)? = nil
+            router.register(action: "act") { _, reply in receivedReply = reply }
+            let sentReply: ([String: Any]) -> Void = { _ in }
+            router.route(message: [SyncConstants.Keys.action: "act"], replyHandler: sentReply)
+            #expect(receivedReply != nil)
+        }
+
+        @Test("Multiple handlers for different actions are independent")
+        func multipleHandlersForDifferentActionsAreIndependent() {
+            let router = SyncCommandRouter()
+            var calledA = false
+            var calledB = false
+            router.register(action: "A") { _, _ in calledA = true }
+            router.register(action: "B") { _, _ in calledB = true }
+            router.route(message: [SyncConstants.Keys.action: "A"], replyHandler: nil)
+            #expect(calledA)
+            #expect(!calledB)
+        }
+
+        @Test("Re-registering action replaces handler")
+        func reregisteringActionReplacesHandler() {
+            let router = SyncCommandRouter()
+            var firstCalled = false
+            var secondCalled = false
+            router.register(action: "act") { _, _ in firstCalled = true }
+            router.register(action: "act") { _, _ in secondCalled = true }
+            router.route(message: [SyncConstants.Keys.action: "act"], replyHandler: nil)
+            #expect(!firstCalled)
+            #expect(secondCalled)
+        }
+}

--- a/companion-testing/SyncImageRegressionTests.swift
+++ b/companion-testing/SyncImageRegressionTests.swift
@@ -1,15 +1,10 @@
 import Foundation
 import Testing
 
-#if canImport(companion)
-    @testable import companion
-#elseif canImport(shared)
-    @testable import shared
-#endif
+@testable import focuswatch_companion
 
-#if canImport(companion) || canImport(shared)
-    @Suite("Image Sync Session Regression")
-    struct SyncImageRegressionTests {
+@Suite("Image Sync Session Regression")
+struct SyncImageRegressionTests {
         @Test("Acknowledgment progression reaches completion")
         func acknowledgmentProgressionReachesCompletion() {
             let tracker = SyncSessionTracker()
@@ -72,5 +67,81 @@ import Testing
 
             #expect(tracker.currentState == nil)
         }
-    }
-#endif
+
+        @Test("Cancel sync clears current state")
+        func cancelSyncClearsCurrentState() {
+            let tracker = SyncSessionTracker()
+            tracker.startNewSync(id: "sync-4", requiredImages: ["img-a"])
+            tracker.cancelCurrentSync()
+            #expect(tracker.currentState == nil)
+        }
+
+        @Test("Clear resets to nil with required images")
+        func clearResetsToNilWithRequiredImages() {
+            let tracker = SyncSessionTracker()
+            tracker.startNewSync(id: "sync-5", requiredImages: ["img-a", "img-b"])
+            tracker.clear()
+            #expect(tracker.currentState == nil)
+        }
+
+        @Test("markImageTransferred removes from failed images")
+        func markImageTransferredRemovesFromFailed() {
+            let tracker = SyncSessionTracker()
+            tracker.startNewSync(id: "sync-6", requiredImages: ["img-a"])
+            tracker.updateState { state in
+                state.markImageFailed("img-a")
+            }
+            #expect(tracker.currentState?.failedImages.contains("img-a") == true)
+            tracker.updateState { state in
+                state.markImageTransferred("img-a")
+            }
+            #expect(tracker.currentState?.failedImages.contains("img-a") == false)
+        }
+
+        @Test("markImagesAcknowledged removes from failed images")
+        func markImagesAcknowledgedRemovesFromFailed() {
+            let tracker = SyncSessionTracker()
+            tracker.startNewSync(id: "sync-7", requiredImages: ["img-a"])
+            tracker.updateState { state in
+                state.markImageFailed("img-a")
+            }
+            tracker.updateState { state in
+                state.markImagesAcknowledged(["img-a"])
+            }
+            #expect(tracker.currentState?.failedImages.contains("img-a") == false)
+        }
+
+        @Test("incrementRetry increments retryCount by one each call")
+        func incrementRetryIncrementsRetryCountByOne() {
+            let tracker = SyncSessionTracker()
+            tracker.startNewSync(id: "sync-8", requiredImages: [])
+            for _ in 0..<3 {
+                tracker.updateState { state in state.incrementRetry() }
+            }
+            #expect(tracker.currentState?.retryCount == 3)
+        }
+
+        @Test("missingImages is required minus acknowledged")
+        func missingImagesIsRequiredMinusAcknowledged() {
+            let tracker = SyncSessionTracker()
+            tracker.startNewSync(id: "sync-9", requiredImages: ["a", "b", "c"])
+            tracker.updateState { state in
+                state.markImagesAcknowledged(["a"])
+            }
+            #expect(tracker.currentState?.missingImages == ["b", "c"])
+        }
+
+        @Test("isComplete requires both checklist synced and all images acknowledged")
+        func isCompleteRequiresBothChecklistAndImages() {
+            let tracker = SyncSessionTracker()
+            tracker.startNewSync(id: "sync-10", requiredImages: ["img-a"])
+            tracker.updateState { state in
+                state.markImagesAcknowledged(["img-a"])
+            }
+            #expect(tracker.currentState?.isComplete == false)
+            tracker.updateState { state in
+                state.markChecklistSynced()
+            }
+            #expect(tracker.currentState?.isComplete == true)
+        }
+}

--- a/companion-testing/SyncPacketTests.swift
+++ b/companion-testing/SyncPacketTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+
+@testable import focuswatch_companion
+
+@Suite("SyncPacket Encoding")
+struct SyncPacketTests {
+        @Test("Encode and decode preserves all fields")
+        func encodeAndDecodePreservesAllFields() throws {
+            let payload = try JSONEncoder().encode(["key": "value"])
+            let timestamp = Date(timeIntervalSince1970: 1_000_000)
+            let metadata = ["k1": "v1", "k2": "v2"]
+            let packet = SyncPacket(
+                type: .checklist,
+                payload: payload,
+                timestamp: timestamp,
+                metadata: metadata
+            )
+
+            let data = try packet.encode()
+            let decoded = try SyncPacket.decode(from: data)
+
+            #expect(decoded.type == packet.type)
+            #expect(decoded.payload == packet.payload)
+            #expect(decoded.timestamp.timeIntervalSince1970 == packet.timestamp.timeIntervalSince1970)
+            #expect(decoded.metadata == packet.metadata)
+        }
+
+        @Test("Encode and decode with nil metadata")
+        func encodeAndDecodeWithNilMetadata() throws {
+            let packet = SyncPacket(type: .level, payload: Data([1, 2, 3]), metadata: nil)
+            let decoded = try SyncPacket.decode(from: try packet.encode())
+            #expect(decoded.metadata == nil)
+        }
+
+        @Test("Decode from data produces identical value to encode")
+        func decodeFromDataProducesIdenticalValue() throws {
+            let packet = SyncPacket(type: .calendar, payload: Data("hello".utf8), metadata: ["a": "b"])
+            let encoded = try packet.encode()
+            let decoded = try SyncPacket.decode(from: encoded)
+            #expect(decoded.type == packet.type)
+            #expect(decoded.payload == packet.payload)
+            #expect(decoded.metadata == packet.metadata)
+        }
+
+        @Test("Encoded data is valid JSON")
+        func encodedDataIsValidJSON() throws {
+            let packet = SyncPacket(type: .config, payload: Data(), metadata: nil)
+            let data = try packet.encode()
+            let json = try JSONSerialization.jsonObject(with: data)
+            #expect(json is [String: Any])
+        }
+
+        @Test("All SyncMessageTypes survive round-trip")
+        func allMessageTypesRoundTrip() throws {
+            let types: [SyncMessageType] = [.calendar, .checklist, .level, .config, .auth, .telemetry, .command, .watchUUID]
+            for type_ in types {
+                let packet = SyncPacket(type: type_, payload: Data())
+                let decoded = try SyncPacket.decode(from: try packet.encode())
+                #expect(decoded.type == type_)
+            }
+        }
+}

--- a/companion-testing/SyncStateManagerTests.swift
+++ b/companion-testing/SyncStateManagerTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import focuswatch_companion
+
+@Suite("SyncStateManager")
+struct SyncStateManagerTests {
+        @Test("startNewSync creates current state")
+        func startNewSyncCreatesCurrentState() {
+            let store = MockSyncSessionStateStore()
+            let manager = SyncStateManager(store: store)
+            manager.startNewSync(id: "sync-1", requiredImages: ["img-a"])
+            #expect(manager.currentState != nil)
+            #expect(manager.currentState?.id == "sync-1")
+            #expect(manager.currentState?.requiredImages == ["img-a"])
+        }
+
+        @Test("startNewSync while incomplete archives to history")
+        func startNewSyncWhileIncompleteArchivesToHistory() {
+            let store = MockSyncSessionStateStore()
+            let manager = SyncStateManager(store: store)
+            manager.startNewSync(id: "sync-1", requiredImages: ["img-a"])
+            manager.startNewSync(id: "sync-2", requiredImages: [])
+            #expect(manager.syncHistory.count == 1)
+            #expect(manager.syncHistory.first?.id == "sync-1")
+            #expect(manager.currentState?.id == "sync-2")
+        }
+
+        @Test("updateState propagates change")
+        func updateStatePropagatesChange() {
+            let store = MockSyncSessionStateStore()
+            let manager = SyncStateManager(store: store)
+            manager.startNewSync(id: "sync-1", requiredImages: [])
+            manager.updateState { state in
+                state.markChecklistSynced()
+            }
+            #expect(manager.currentState?.checklistSynced == true)
+        }
+
+        @Test("completeCurrentSync moves to history")
+        func completeCurrentSyncMovesToHistory() {
+            let store = MockSyncSessionStateStore()
+            let manager = SyncStateManager(store: store)
+            manager.startNewSync(id: "sync-1", requiredImages: [])
+            manager.completeCurrentSync()
+            #expect(manager.currentState == nil)
+            #expect(manager.syncHistory.count == 1)
+            #expect(manager.syncHistory.first?.id == "sync-1")
+        }
+
+        @Test("cancelCurrentSync increments retry in history")
+        func cancelCurrentSyncIncrementsRetryInHistory() {
+            let store = MockSyncSessionStateStore()
+            let manager = SyncStateManager(store: store)
+            manager.startNewSync(id: "sync-1", requiredImages: [])
+            manager.cancelCurrentSync()
+            #expect(manager.currentState == nil)
+            #expect(manager.syncHistory.first?.retryCount == 1)
+        }
+
+        @Test("clearAll resets everything")
+        func clearAllResetsEverything() {
+            let store = MockSyncSessionStateStore()
+            let manager = SyncStateManager(store: store)
+            manager.startNewSync(id: "sync-1", requiredImages: [])
+            manager.completeCurrentSync()
+            manager.startNewSync(id: "sync-2", requiredImages: [])
+            manager.clearAll()
+            #expect(manager.currentState == nil)
+            #expect(manager.syncHistory.isEmpty)
+        }
+
+        @Test("loadState restores from store")
+        func loadStateRestoresFromStore() {
+            let store = MockSyncSessionStateStore()
+            let savedState = SyncState(id: "saved-sync", requiredImages: ["img-x"])
+            store.storedState = savedState
+
+            let manager = SyncStateManager(store: store)
+            #expect(manager.currentState?.id == "saved-sync")
+            #expect(manager.currentState?.requiredImages == ["img-x"])
+        }
+}

--- a/companion/Services/ChecklistDataStore.swift
+++ b/companion/Services/ChecklistDataStore.swift
@@ -7,8 +7,6 @@ final class ChecklistDataStore: ObservableObject {
     @Published private(set) var checklistData: ChecklistData = .default
 
     private let userDefaults: UserDefaults
-    private let persistenceQueue = DispatchQueue(
-        label: "com.fokusuhr.checklist.persistence", qos: .utility)
     private let debounceInterval: TimeInterval
     private var cancellables = Set<AnyCancellable>()
 
@@ -34,16 +32,14 @@ final class ChecklistDataStore: ObservableObject {
     }
 
     private func saveChecklistData(_ data: ChecklistData) {
-        persistenceQueue.async { [userDefaults] in
-            do {
-                let encodedData = try JSONEncoder().encode(data)
-                userDefaults.set(encodedData, forKey: AppConstants.StorageKeys.checklistData)
-            } catch {
-                #if DEBUG
-                    ErrorLogger.log(
-                        AppError.encodingFailed(type: "checklist data", underlying: error))
-                #endif
-            }
+        do {
+            let encodedData = try JSONEncoder().encode(data)
+            userDefaults.set(encodedData, forKey: AppConstants.StorageKeys.checklistData)
+        } catch {
+            #if DEBUG
+                ErrorLogger.log(
+                    AppError.encodingFailed(type: "checklist data", underlying: error))
+            #endif
         }
     }
 

--- a/shared/Services/LevelService.swift
+++ b/shared/Services/LevelService.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import SwiftData
 import UserNotifications
@@ -15,17 +16,18 @@ class LevelService: ObservableObject {
     private let container: ModelContainer
     internal let context: ModelContext
 
-    #if os(watchOS)
-        private let vibrationManager = VibrationManager.shared
-    #endif
     private let loadMilestones: () -> [LevelMilestone]
     #if os(watchOS)
         private let notifyLevelChange: () -> Void
+        private let hapticForXP: () -> Void
+        private let hapticForLevelUp: () -> Void
     #endif
 
     private init(
         loadMilestones: (() -> [LevelMilestone])? = nil,
-        notifyLevelChange: (() -> Void)? = nil
+        notifyLevelChange: (() -> Void)? = nil,
+        hapticForXP: (() -> Void)? = nil,
+        hapticForLevelUp: (() -> Void)? = nil
     ) {
         self.loadMilestones =
             loadMilestones
@@ -42,6 +44,8 @@ class LevelService: ObservableObject {
                 ?? {
                     SyncCoordinator.shared.syncLevelToiOS()
                 }
+            self.hapticForXP = hapticForXP ?? { WKInterfaceDevice.current().play(.click) }
+            self.hapticForLevelUp = hapticForLevelUp ?? { WKInterfaceDevice.current().play(.success) }
         #endif
 
         let schema = Schema([
@@ -91,7 +95,7 @@ class LevelService: ObservableObject {
         progress.lastUpdated = Date()
 
         #if os(watchOS)
-            vibrationManager.playHaptic(.click)
+            hapticForXP()
         #endif
 
         while progress.currentXP >= progress.xpNeededForNextLevel {
@@ -126,10 +130,10 @@ class LevelService: ObservableObject {
 
     private func handleLevelUp(newLevel: Int) {
         #if os(watchOS)
-            vibrationManager.playHaptic(.success)
+            hapticForLevelUp()
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
-                self?.vibrationManager.playHaptic(.success)
+                self?.hapticForLevelUp()
             }
         #endif
 

--- a/shared/Services/SupervisorManager.swift
+++ b/shared/Services/SupervisorManager.swift
@@ -1,5 +1,8 @@
+import Auth
 import Combine
 import Foundation
+import PostgREST
+import Supabase
 import SwiftUI
 
 typealias Supervisor = PublicSchema.UserProfilesSelect

--- a/shared/Services/TelemetryManager.swift
+++ b/shared/Services/TelemetryManager.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 #if os(iOS)

--- a/shared/Services/TestUsersManager.swift
+++ b/shared/Services/TestUsersManager.swift
@@ -1,6 +1,7 @@
+import Combine
 import Foundation
 import PostgREST
-import Combine
+import Supabase
 import SwiftUI
 
 typealias TestUser = PublicSchema.TestUsersSelect

--- a/watch-testing/IncomingContextHandlerTests.swift
+++ b/watch-testing/IncomingContextHandlerTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Testing
+
+@testable import focuswatch_watch
+
+@Suite("IncomingContextHandler")
+struct IncomingContextHandlerTests {
+        private func makeChecklistBytes() throws -> Data {
+            try JSONEncoder().encode(ChecklistData(checklists: [Checklist(name: "Test")]))
+        }
+
+        @Test("checklistData key triggers checklistManager update")
+        @MainActor
+        func checklistDataKeyTriggersChecklistManagerUpdate() throws {
+            let checklist = MockChecklistViewModel()
+            let gallery = MockGalleryManager()
+            let handler = IncomingContextHandler(checklistManager: checklist, galleryManager: gallery)
+
+            let bytes = try makeChecklistBytes()
+            let context: [String: Any] = [SyncConstants.Keys.checklistData: bytes]
+
+            handler.handle(
+                context,
+                updateCalendarEvents: { _ in },
+                handleLevelUpdate: { _ in },
+                handleConfigurationsUpdate: { _ in },
+                handleLegacyAction: { _, _ in }
+            )
+
+            #expect(checklist.updateCalls.count == 1)
+            #expect(checklist.updateCalls.first?.data == bytes)
+            #expect(checklist.updateCalls.first?.forceOverwrite == false)
+        }
+
+        @Test("checklistData with images calls saveGalleryImages")
+        @MainActor
+        func checklistDataWithImagesCallsSaveGalleryImages() throws {
+            let checklist = MockChecklistViewModel()
+            let gallery = MockGalleryManager()
+            let handler = IncomingContextHandler(checklistManager: checklist, galleryManager: gallery)
+
+            let bytes = try makeChecklistBytes()
+            let imageData: [String: Data] = ["img-a": Data([1, 2, 3])]
+            let context: [String: Any] = [
+                SyncConstants.Keys.checklistData: bytes,
+                SyncConstants.Keys.checklistImageData: imageData,
+            ]
+
+            handler.handle(
+                context,
+                updateCalendarEvents: { _ in },
+                handleLevelUpdate: { _ in },
+                handleConfigurationsUpdate: { _ in },
+                handleLegacyAction: { _, _ in }
+            )
+
+            #expect(gallery.savedImageDataCalls.count == 1)
+            #expect(gallery.savedImageDataCalls.first?["img-a"] == Data([1, 2, 3]))
+        }
+
+        @Test("checklistData without images does not call saveGalleryImages")
+        @MainActor
+        func checklistDataWithoutImagesDoesNotCallSaveGalleryImages() throws {
+            let checklist = MockChecklistViewModel()
+            let gallery = MockGalleryManager()
+            let handler = IncomingContextHandler(checklistManager: checklist, galleryManager: gallery)
+
+            let bytes = try makeChecklistBytes()
+            let context: [String: Any] = [SyncConstants.Keys.checklistData: bytes]
+
+            handler.handle(
+                context,
+                updateCalendarEvents: { _ in },
+                handleLevelUpdate: { _ in },
+                handleConfigurationsUpdate: { _ in },
+                handleLegacyAction: { _, _ in }
+            )
+
+            #expect(gallery.savedImageDataCalls.isEmpty)
+        }
+
+        @Test("levelData key triggers handleLevelUpdate callback")
+        @MainActor
+        func levelDataKeyTriggersLevelUpdateCallback() {
+            let checklist = MockChecklistViewModel()
+            let gallery = MockGalleryManager()
+            let handler = IncomingContextHandler(checklistManager: checklist, galleryManager: gallery)
+
+            let levelBytes = Data([1, 2, 3])
+            let context: [String: Any] = [SyncConstants.Keys.levelData: levelBytes]
+
+            var receivedData: Data?
+            handler.handle(
+                context,
+                updateCalendarEvents: { _ in },
+                handleLevelUpdate: { receivedData = $0 },
+                handleConfigurationsUpdate: { _ in },
+                handleLegacyAction: { _, _ in }
+            )
+
+            #expect(receivedData == levelBytes)
+        }
+
+        @Test("configData key triggers handleConfigurationsUpdate callback")
+        @MainActor
+        func configDataKeyTriggersConfigurationsCallback() {
+            let checklist = MockChecklistViewModel()
+            let gallery = MockGalleryManager()
+            let handler = IncomingContextHandler(checklistManager: checklist, galleryManager: gallery)
+
+            let configBytes = Data([9, 8, 7])
+            let context: [String: Any] = [SyncConstants.Keys.appConfigurations: configBytes]
+
+            var receivedData: Data?
+            handler.handle(
+                context,
+                updateCalendarEvents: { _ in },
+                handleLevelUpdate: { _ in },
+                handleConfigurationsUpdate: { receivedData = $0 },
+                handleLegacyAction: { _, _ in }
+            )
+
+            #expect(receivedData == configBytes)
+        }
+
+        @Test("handle returns true when checklistData is present")
+        @MainActor
+        func handleReturnsTrueWhenChecklistDataPresent() throws {
+            let handler = IncomingContextHandler(
+                checklistManager: MockChecklistViewModel(),
+                galleryManager: MockGalleryManager()
+            )
+            let bytes = try makeChecklistBytes()
+            let result = handler.handle(
+                [SyncConstants.Keys.checklistData: bytes],
+                updateCalendarEvents: { _ in },
+                handleLevelUpdate: { _ in },
+                handleConfigurationsUpdate: { _ in },
+                handleLegacyAction: { _, _ in }
+            )
+            #expect(result)
+        }
+
+        @Test("handle returns false when no checklistData is present")
+        @MainActor
+        func handleReturnsFalseWhenNoChecklistDataPresent() {
+            let handler = IncomingContextHandler(
+                checklistManager: MockChecklistViewModel(),
+                galleryManager: MockGalleryManager()
+            )
+            let result = handler.handle(
+                [SyncConstants.Keys.levelData: Data([1])],
+                updateCalendarEvents: { _ in },
+                handleLevelUpdate: { _ in },
+                handleConfigurationsUpdate: { _ in },
+                handleLegacyAction: { _, _ in }
+            )
+            #expect(!result)
+        }
+
+        @Test("missing images key in context does not crash")
+        @MainActor
+        func missingImagesKeyDoesNotCrash() throws {
+            let handler = IncomingContextHandler(
+                checklistManager: MockChecklistViewModel(),
+                galleryManager: MockGalleryManager()
+            )
+            let bytes = try makeChecklistBytes()
+            handler.handle(
+                [SyncConstants.Keys.checklistData: bytes],
+                updateCalendarEvents: { _ in },
+                handleLevelUpdate: { _ in },
+                handleConfigurationsUpdate: { _ in },
+                handleLegacyAction: { _, _ in }
+            )
+        }
+}

--- a/watch-testing/IncomingFileHandlerTests.swift
+++ b/watch-testing/IncomingFileHandlerTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+
+@testable import focuswatch_watch
+
+@Suite("IncomingFileHandler")
+struct IncomingFileHandlerTests {
+        private func makeURL() -> URL {
+            URL(fileURLWithPath: "/tmp/test-file.jpg")
+        }
+
+        @Test("nil metadata is ignored")
+        @MainActor
+        func missingMetadataIsIgnored() {
+            let gallery = MockGalleryManager()
+            let handler = IncomingFileHandler(galleryManager: gallery)
+            handler.handle(fileURL: makeURL(), metadata: nil)
+            #expect(gallery.receivedFileCalls.isEmpty)
+        }
+
+        @Test("metadata without syncType key is ignored")
+        @MainActor
+        func missingSyncTypeKeyInMetadataIsIgnored() {
+            let gallery = MockGalleryManager()
+            let handler = IncomingFileHandler(galleryManager: gallery)
+            handler.handle(fileURL: makeURL(), metadata: ["other": "value"])
+            #expect(gallery.receivedFileCalls.isEmpty)
+        }
+
+        @Test("checklist syncType routes to galleryManager")
+        @MainActor
+        func checklistSyncTypeRoutesToGalleryManager() {
+            let gallery = MockGalleryManager()
+            let handler = IncomingFileHandler(galleryManager: gallery)
+            let url = makeURL()
+            let metadata: [String: Any] = [SyncConstants.Keys.syncType: SyncMessageType.checklist.rawValue]
+            handler.handle(fileURL: url, metadata: metadata)
+            #expect(gallery.receivedFileCalls.count == 1)
+            #expect(gallery.receivedFileCalls.first?.0 == url)
+        }
+
+        @Test("unknown syncType is ignored")
+        @MainActor
+        func unknownSyncTypeIsIgnored() {
+            let gallery = MockGalleryManager()
+            let handler = IncomingFileHandler(galleryManager: gallery)
+            handler.handle(
+                fileURL: makeURL(),
+                metadata: [SyncConstants.Keys.syncType: "unknown_type"]
+            )
+            #expect(gallery.receivedFileCalls.isEmpty)
+        }
+}

--- a/watch-testing/MockChecklistViewModel.swift
+++ b/watch-testing/MockChecklistViewModel.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+@testable import focuswatch_watch
+
+final class MockChecklistViewModel: ChecklistViewModel {
+    private(set) var updateCalls: [(data: Data, forceOverwrite: Bool)] = []
+
+    override func updateChecklistData(from data: Data, forceOverwrite: Bool = false) {
+        updateCalls.append((data: data, forceOverwrite: forceOverwrite))
+    }
+}

--- a/watch-testing/MockGalleryManager.swift
+++ b/watch-testing/MockGalleryManager.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+@testable import focuswatch_watch
+
+final class MockGalleryManager: GalleryManager {
+    private(set) var savedImageDataCalls: [[String: Data]] = []
+    private(set) var receivedFileCalls: [(URL, [String: Any]?)] = []
+
+    override func saveGalleryImages(_ imageData: [String: Data]) {
+        savedImageDataCalls.append(imageData)
+    }
+
+    override func handleReceivedFile(fileURL: URL, metadata: [String: Any]?) {
+        receivedFileCalls.append((fileURL, metadata))
+    }
+}

--- a/watch-testing/SyncValidationServiceTests.swift
+++ b/watch-testing/SyncValidationServiceTests.swift
@@ -1,13 +1,10 @@
 import Foundation
 import Testing
 
-#if canImport(watch)
-    @testable import watch
-#endif
+@testable import focuswatch_watch
 
-#if canImport(watch)
-    @Suite("Watch Sync Validation Regression")
-    struct SyncValidationServiceTests {
+@Suite("Watch Sync Validation Regression")
+struct SyncValidationServiceTests {
         @Test("No required images is immediately complete")
         @MainActor
         func noRequiredImagesIsImmediatelyComplete() {
@@ -77,5 +74,148 @@ import Testing
             #expect(requestCount == 1)
             #expect(requestedImages == [["img-b"]])
         }
-    }
-#endif
+
+        @Test("All images exist returns complete")
+        @MainActor
+        func allImagesExistReturnsComplete() {
+            let service = SyncValidationService()
+            let data = ChecklistData(
+                checklists: [
+                    Checklist(
+                        name: "List",
+                        items: [
+                            ChecklistItem(title: "A", imageName: "img-a"),
+                            ChecklistItem(title: "B", imageName: "img-b"),
+                        ]
+                    )
+                ]
+            )
+            let result = service.validate(
+                checklistData: data,
+                transportReachable: true,
+                imageExists: { _ in true },
+                requestMissingImages: { _ in }
+            )
+            #expect(result.status == SyncConstants.Status.complete)
+            #expect(result.progress == 1.0)
+            #expect(result.missingImages.isEmpty)
+        }
+
+        @Test("No images exist returns pending")
+        @MainActor
+        func noImagesExistReturnsPending() {
+            let service = SyncValidationService()
+            let data = ChecklistData(
+                checklists: [
+                    Checklist(
+                        name: "List",
+                        items: [
+                            ChecklistItem(title: "A", imageName: "img-a"),
+                            ChecklistItem(title: "B", imageName: "img-b"),
+                        ]
+                    )
+                ]
+            )
+            let result = service.validate(
+                checklistData: data,
+                transportReachable: false,
+                imageExists: { _ in false },
+                requestMissingImages: { _ in }
+            )
+            #expect(result.status == SyncConstants.Status.pending)
+            #expect(result.progress == 0.0)
+        }
+
+        @Test("Some images exist returns partial with correct progress")
+        @MainActor
+        func someImagesExistReturnsPartial() {
+            let service = SyncValidationService()
+            let data = ChecklistData(
+                checklists: [
+                    Checklist(
+                        name: "List",
+                        items: [
+                            ChecklistItem(title: "A", imageName: "img-a"),
+                            ChecklistItem(title: "B", imageName: "img-b"),
+                            ChecklistItem(title: "C", imageName: "img-c"),
+                            ChecklistItem(title: "D", imageName: "img-d"),
+                        ]
+                    )
+                ]
+            )
+            let result = service.validate(
+                checklistData: data,
+                transportReachable: false,
+                imageExists: { name in name == "img-a" || name == "img-b" },
+                requestMissingImages: { _ in }
+            )
+            #expect(result.status == SyncConstants.Status.partial)
+            #expect(abs(result.progress - 0.5) < 0.0001)
+        }
+
+        @Test("Transport not reachable skips request")
+        @MainActor
+        func transportNotReachableSkipsRequest() {
+            let service = SyncValidationService()
+            let data = ChecklistData(
+                checklists: [Checklist(name: "L", items: [ChecklistItem(title: "A", imageName: "img-a")])]
+            )
+            var requestCount = 0
+            _ = service.validate(
+                checklistData: data,
+                transportReachable: false,
+                imageExists: { _ in false },
+                requestMissingImages: { _ in requestCount += 1 }
+            )
+            #expect(requestCount == 0)
+        }
+
+        @Test("Reset clears pending and allows new request")
+        @MainActor
+        func resetClearsPendingAndAllowsNewRequest() {
+            let service = SyncValidationService()
+            let data = ChecklistData(
+                checklists: [Checklist(name: "L", items: [ChecklistItem(title: "A", imageName: "img-a")])]
+            )
+            var requestCount = 0
+            _ = service.validate(
+                checklistData: data,
+                transportReachable: true,
+                imageExists: { _ in false },
+                requestMissingImages: { _ in requestCount += 1 }
+            )
+            service.reset()
+            _ = service.validate(
+                checklistData: data,
+                transportReachable: true,
+                imageExists: { _ in false },
+                requestMissingImages: { _ in requestCount += 1 }
+            )
+            #expect(requestCount == 2)
+        }
+
+        @Test("Empty imageName items are excluded from required set")
+        @MainActor
+        func emptyItemImageNamesAreExcludedFromRequired() {
+            let service = SyncValidationService()
+            let data = ChecklistData(
+                checklists: [
+                    Checklist(
+                        name: "List",
+                        items: [
+                            ChecklistItem(title: "No image", imageName: ""),
+                            ChecklistItem(title: "Also no image"),
+                        ]
+                    )
+                ]
+            )
+            let result = service.validate(
+                checklistData: data,
+                transportReachable: true,
+                imageExists: { _ in false },
+                requestMissingImages: { _ in }
+            )
+            #expect(result.status == SyncConstants.Status.complete)
+            #expect(result.missingImages.isEmpty)
+        }
+}


### PR DESCRIPTION
This pull request introduces several improvements and additions to the project, focusing on enhanced testing for core data models, improved developer documentation, and updates to CI and build tooling. The most significant changes are the addition of comprehensive Swift Testing-based test suites for key companion app models and services, expanded setup/build instructions in the documentation, and updates to simulator/device selection for CI workflows.

**Testing Enhancements:**

* Added new Swift Testing (`Testing` framework) suites for core companion app models and services:
  - `AppConfigurations` and related configuration models (`companion-testing/AppConfigurationsTests.swift`)
  - Checklist models and data store, including round-trip encoding/decoding and persistence logic (`companion-testing/ChecklistModelsTests.swift`, `companion-testing/ChecklistDataStoreTests.swift`) [[1]](diffhunk://#diff-e1b2ed7aafe17be9ea588be0ca77c61adfb69c39d6b3bfc7d0e03b432ffe5dd9R1-R90) [[2]](diffhunk://#diff-12502088b38823871920e9facf52b943d5015641b288e2e869c41d1c59221338R1-R48)
  - Level progress and activity type reward logic (`companion-testing/LevelProgressModelTests.swift`, `companion-testing/LevelServiceActivitiesTests.swift`) [[1]](diffhunk://#diff-176754bfb88e948ba5dbbd97830c91e21594a76ebea3e83e9f9d7d7f19e2c0e8R1-R44) [[2]](diffhunk://#diff-01cbce7301c3f06147d86407a046c8f50e9b74b7dce829e571676fc1d8e3fe0bR1-R59)
  - Added a mock implementation for `SyncSessionStateStore` for testing sync session state logic (`companion-testing/MockSyncSessionStateStore.swift`)

**CI/CD and Build Tooling Updates:**

* Updated iOS and watchOS CI workflow to use newer simulators (`iPhone 17 Pro`, `Apple Watch Series 11 (42mm)`), and bumped macOS runner for watchOS jobs. [[1]](diffhunk://#diff-9924bab9fea4f8ff6538b260569bcc41c31712986c57d4e5db6a7bb7607d8f80L29-R37) [[2]](diffhunk://#diff-9924bab9fea4f8ff6538b260569bcc41c31712986c57d4e5db6a7bb7607d8f80L54-R54)
* Updated project name in `Makefile` to match the Xcode project file.
* Adjusted scheme order hints in `xcschememanagement.plist` for better scheme organization.